### PR TITLE
docs: minimal DRB framing — market FOR $DRB price moves

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ The contracts in this repo are written, reviewed, and merged by an autonomous Cl
 
 ## What we're building
 
-A prediction market where **AI agents bet against each other on $DRB token price direction** — does the price move up or down over the resolution window? The market resolves against on-chain price from the canonical DRB/WETH 1% Uniswap V3 pool on Base, and settles in DRB. Built for agent-to-agent counterparty action — no human intermediary, no wallet UI.
-
-The protocol design — resolution mechanism, market lifecycle, agent interaction patterns — is in active research. The synthesized brief lands at `projects/drb/brief.md` once research is complete; from there the build proceeds task by task through the GAN loop described below.
+An on-chain prediction market for **$DRB token price moves** on Base. Protocol details — settlement currency, resolution mechanism, market mechanics — are in active research and not yet finalized. The synthesized brief lands at `projects/drb/brief.md` once research is complete; from there the build proceeds task by task through the GAN loop described below.
 
 ## How it gets built — the GAN loop
 

--- a/projects/drb/README.md
+++ b/projects/drb/README.md
@@ -1,1 +1,6 @@
-DRB is an on-chain prediction market on Base where AI agents bet against each other on **$DRB token price direction** — does the price move up or down over the resolution window? The market resolves against on-chain price from the canonical DRB/WETH 1% Uniswap V3 pool (`0x5116773e18a9c7bb03ebb961b38678e45e238923`) and settles in DRB token (`0x3ec2156D4c0A9CBdAB4a016633b7BcF6a8d68Ea2`) on Base (chain ID 8453). Designed for agent-to-agent counterparty action: no humans, no UI, no wallets-with-humans-attached. Two agents take opposite sides; the contract settles based on actual price movement at the close.
+An on-chain prediction market for **$DRB token price moves** on Base.
+
+DRB token: `0x3ec2156D4c0A9CBdAB4a016633b7BcF6a8d68Ea2` (Base, chain id 8453).
+On-chain price source: DRB/WETH 1% Uniswap V3 pool at `0x5116773e18a9c7bb03ebb961b38678e45e238923`.
+
+Protocol details — settlement currency, resolution mechanism, market mechanics — are in active research and not yet finalized.


### PR DESCRIPTION
Operator correction. Both READMEs were too prescriptive. Stripped: 'settles in DRB' (settlement currency undecided), 'DRB is an on-chain prediction market' (DRB is the token, not the market name), and the two-sided-counterparty speculation. General-only description until the brief lands.